### PR TITLE
Add core data db url, fix a bug in any stores, add more tests

### DIFF
--- a/Sources/Blueprints/AnyMultiObjectStore.swift
+++ b/Sources/Blueprints/AnyMultiObjectStore.swift
@@ -111,6 +111,9 @@ public extension MultiObjectStore {
   /// Create a type erased store.
   /// - Returns: ``AnyMultiObjectStore``.
   func eraseToAnyStore() -> AnyMultiObjectStore<Object> {
+    if let anyStore = self as? AnyMultiObjectStore<Object> {
+      return anyStore
+    }
     return .init(self)
   }
 }

--- a/Sources/Blueprints/AnySingleObjectStore.swift
+++ b/Sources/Blueprints/AnySingleObjectStore.swift
@@ -47,6 +47,9 @@ public extension SingleObjectStore {
   /// Create a type erased store.
   /// - Returns: ``AnySingleObjectStore``.
   func eraseToAnyStore() -> AnySingleObjectStore<Object> {
+    if let anyStore = self as? AnySingleObjectStore<Object> {
+      return anyStore
+    }
     return .init(self)
   }
 }

--- a/Sources/CoreData/Database.swift
+++ b/Sources/CoreData/Database.swift
@@ -11,17 +11,19 @@ private final class Container: NSPersistentContainer {
 
 final class Database {
   let context: NSManagedObjectContext
+  private(set) var url: URL?
 
   init(name: String) {
     let container = Container(name: name, managedObjectModel: Self.entityModel)
-    container.loadPersistentStores { _, error in
+    context = container.viewContext
+    container.loadPersistentStores { description, error in
       if let error = error {
         preconditionFailure(
           "Failed to load store with error: \(error.localizedDescription)."
         )
       }
+      self.url = description.url
     }
-    context = container.viewContext
   }
 
   static let entityModel: NSManagedObjectModel = {
@@ -64,6 +66,7 @@ final class Database {
   let entityFetchRequest: (String) -> NSFetchRequest<Entity> = { id in
     let request = NSFetchRequest<Entity>(entityName: "Entity")
     request.predicate = NSPredicate(format: "id == %@", id)
+    request.fetchLimit = 1
     return request
   }
 }

--- a/Sources/CoreData/MultiCoreDataStore.swift
+++ b/Sources/CoreData/MultiCoreDataStore.swift
@@ -38,6 +38,11 @@ public final class MultiCoreDataStore<
     database = .init(name: databaseName)
   }
 
+  /// URL for where the core data SQLite database is stored.
+  public var databaseURL: URL? {
+    database.url
+  }
+
   // MARK: - MultiObjectStore
 
   /// Saves an object to store.

--- a/Sources/CoreData/SingleCoreDataStore.swift
+++ b/Sources/CoreData/SingleCoreDataStore.swift
@@ -37,7 +37,12 @@ public final class SingleCoreDataStore<Object: Codable>: SingleObjectStore {
     database = .init(name: databaseName)
   }
 
-  // MARK: - Store
+  /// URL for where the core data SQLite database is stored.
+  public var databaseURL: URL? {
+    database.url
+  }
+
+  // MARK: - SingleObjectStore
 
   /// Saves an object to store.
   /// - Parameter object: object to be saved.

--- a/Tests/Blueprints/AnyMultiObjectStoreTests.swift
+++ b/Tests/Blueprints/AnyMultiObjectStoreTests.swift
@@ -94,6 +94,7 @@ private extension AnyMultiObjectStoreTests {
   func createFreshUsersStores() -> Stores {
     let fakeStore = MultiObjectStoreFake<User>()
     let anyStore = fakeStore.eraseToAnyStore()
+    XCTAssert(anyStore.eraseToAnyStore() === anyStore)
     return (fakeStore, anyStore)
   }
 }

--- a/Tests/Blueprints/AnySingleObjectStoreTests.swift
+++ b/Tests/Blueprints/AnySingleObjectStoreTests.swift
@@ -42,6 +42,7 @@ private extension AnySingleObjectStoreTests {
   func createFreshUserStores() -> Stores {
     let fakeStore = SingleObjectStoreFake<User>()
     let anyStore = fakeStore.eraseToAnyStore()
+    XCTAssert(anyStore.eraseToAnyStore() === anyStore)
     return (fakeStore, anyStore)
   }
 }

--- a/Tests/CoreData/DatabaseTests.swift
+++ b/Tests/CoreData/DatabaseTests.swift
@@ -17,17 +17,41 @@ final class DatabaseTests: XCTestCase {
     }
     XCTAssertEqual(properties.count, 3)
 
-    XCTAssertEqual(properties[0].name, "id")
-    XCTAssertEqual(properties[0].attributeType, .stringAttributeType)
-    XCTAssertFalse(properties[0].isOptional)
+    let sortedProperties = properties.sorted { $0.name < $1.name }
 
-    XCTAssertEqual(properties[1].name, "data")
-    XCTAssertEqual(properties[1].attributeType, .binaryDataAttributeType)
-    XCTAssertFalse(properties[1].isOptional)
+    XCTAssertEqual(sortedProperties[0].name, "data")
+    XCTAssertEqual(sortedProperties[0].attributeType, .binaryDataAttributeType)
+    XCTAssertFalse(sortedProperties[0].isOptional)
 
-    XCTAssertEqual(properties[2].name, "lastUpdated")
-    XCTAssertEqual(properties[2].attributeType, .dateAttributeType)
-    XCTAssertFalse(properties[2].isOptional)
+    XCTAssertEqual(sortedProperties[1].name, "id")
+    XCTAssertEqual(sortedProperties[1].attributeType, .stringAttributeType)
+    XCTAssertFalse(sortedProperties[1].isOptional)
+
+    XCTAssertEqual(sortedProperties[2].name, "lastUpdated")
+    XCTAssertEqual(sortedProperties[2].attributeType, .dateAttributeType)
+    XCTAssertFalse(sortedProperties[2].isOptional)
+  }
+
+  func testEntitiesFetchRequest() {
+    let database = Database(name: "test")
+    let request = database.entitiesFetchRequest()
+    XCTAssertEqual(request.entityName, "Entity")
+    XCTAssertEqual(
+      request.sortDescriptors,
+      [.init(key: "lastUpdated", ascending: true)]
+    )
+  }
+
+  func testEntityFetchRequest() {
+    let database = Database(name: "test")
+    let id = "test-id"
+    let request = database.entityFetchRequest(id)
+    XCTAssertEqual(request.entityName, "Entity")
+    XCTAssertEqual(
+      request.predicate,
+      NSPredicate(format: "id == %@", id)
+    )
+    XCTAssertEqual(request.fetchLimit, 1)
   }
 }
 

--- a/Tests/CoreData/MultiCoreDataStoreTests.swift
+++ b/Tests/CoreData/MultiCoreDataStoreTests.swift
@@ -15,9 +15,20 @@ final class MultiCoreDataStoreTests: XCTestCase {
     try store?.removeAll()
   }
 
+  func testCreateStore() {
+    let databaseName = UUID().uuidString
+    let store = createFreshUsersStore(databaseName: databaseName)
+    XCTAssertEqual(store.databaseName, databaseName)
+  }
+
+  func testDatabaseURL() {
+    let store = createFreshUsersStore()
+    let path = store.databaseURL?.pathComponents.suffix(2)
+    XCTAssertEqual(path, ["CoreDataStore", "\(store.databaseName).sqlite"])
+  }
+
   func testSaveObject() throws {
     let store = createFreshUsersStore()
-
     try store.save(.ahmad)
     XCTAssertEqual(store.objectsCount, 1)
     XCTAssertEqual(store.allObjects(), [.ahmad])

--- a/Tests/CoreData/SingleCoreDataStoreTests.swift
+++ b/Tests/CoreData/SingleCoreDataStoreTests.swift
@@ -20,6 +20,12 @@ final class SingleCoreDataStoreTests: XCTestCase {
     XCTAssertEqual(store.databaseName, databaseName)
   }
 
+  func testDatabaseURL() {
+    let store = createFreshUserStore()
+    let path = store.databaseURL?.pathComponents.suffix(2)
+    XCTAssertEqual(path, ["CoreDataStore", "\(store.databaseName).sqlite"])
+  }
+
   func testSaveObject() throws {
     let store = createFreshUserStore()
     try store.save(.ahmad)

--- a/Tests/Utils/MultiObjectStoreFake.swift
+++ b/Tests/Utils/MultiObjectStoreFake.swift
@@ -21,7 +21,7 @@ public final class MultiObjectStoreFake<
     self.error = error
   }
 
-  // MARK: - Store
+  // MARK: - MultiObjectStore
 
   /// Saves an object to store.
   /// - Parameter object: object to be saved.

--- a/Tests/Utils/SingleObjectStoreFake.swift
+++ b/Tests/Utils/SingleObjectStoreFake.swift
@@ -22,7 +22,7 @@ public final class SingleObjectStoreFake<Object: Codable>: SingleObjectStore {
     self.error = error
   }
 
-  // MARK: - Store
+  // MARK: - SingleObjectStore
 
   /// Saves an object to store.
   /// - Parameter object: object to be saved.


### PR DESCRIPTION
- Add `databaseURL` property to core data stores to return SQLite database url.
- Fix a bug where calling `eraseToAnyStore` on an any store is wrapping it again in a new any store.
- Add more tests for code data stores