### PR TITLE
Fix/SPI Framework documentation blank page

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 
 import PackageDescription
 

--- a/Sources/Stores/Stores.docc/Stores.md
+++ b/Sources/Stores/Stores.docc/Stores.md
@@ -1,0 +1,7 @@
+# ``Stores``
+
+A typed key-value storage solution to store Codable types in various persistence layers like User Defaults, File System, Core Data, Keychain, and more with a few lines of code!
+
+## Overview
+
+Stores tries to abstract the concept of a store and provide various implementations that can be injected in such environment and swapped easily when running tests or based on a remote flag.


### PR DESCRIPTION
First attempt to fixing #9

Probable problem: (😅) The Store root file don't have any documentation. 

My proposed solution: 

Since the root level Store file conditionally imports the other framework, i am thinking adding a root level documentation will fix the issue of the docs landing page being empty.  I have added a short summary of the framework description for testing purposes. 

🚨 But for this to work, it's necessary to update the swift-version to 5.5. 

DocC archive: [Stores.doccarchive.zip](https://github.com/omaralbeik/Stores/files/9679423/Stores.doccarchive.zip)

NOTE: -
If this solution works, then i'll proceed to improve the rest of the documentation to ensure uniformity and at most leverage of the interesting features that DocC offers.

To test release, we might need to do a preview-release so that SPI can update the change.

@omaralbeik  let me know what you think 