### PR TITLE
Deprecations and core data stores customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ Stores comes pre-equipped with the following stores:
 
 ```swift
 // Store for multiple objects
-let store = MultiUserDefaultsStore<User>(identifier: "users")
+let store = MultiUserDefaultsStore<User>(suiteName: "users")
 
 // Store for a single object
-let store = SingleUserDefaultsStore<User>(identifier: "users")
+let store = SingleUserDefaultsStore<User>(suiteName: "users")
 ```
 </details>
 </li>
@@ -87,10 +87,10 @@ let store = SingleUserDefaultsStore<User>(identifier: "users")
 
 ```swift
 // Store for multiple objects
-let store = MultiFileSystemStore<User>(identifier: "users")
+let store = MultiFileSystemStore<User>(path: "users")
 
 // Store for a single object
-let store = SingleFileSystemStore<User>(identifier: "users")
+let store = SingleFileSystemStore<User>(path: "users")
 ```
 </details>
 </li>
@@ -101,10 +101,10 @@ let store = SingleFileSystemStore<User>(identifier: "users")
 
 ```swift
 // Store for multiple objects
-let store = MultiCoreDataStore<User>(identifier: "users")
+let store = MultiCoreDataStore<User>(databaseName: "users")
 
 // Store for a single object
-let store = SingleCoreDataStore<User>(identifier: "users")
+let store = SingleCoreDataStore<User>(databaseName: "users")
 ```
 </details>
 </li>

--- a/Sources/CoreData/Database.swift
+++ b/Sources/CoreData/Database.swift
@@ -3,9 +3,13 @@
 import CoreData
 import Foundation
 
-private final class Container: NSPersistentContainer {
+final class Container: NSPersistentContainer {
   override class func defaultDirectoryURL() -> URL {
     super.defaultDirectoryURL().appendingPathComponent("CoreDataStore")
+  }
+
+  required init(name: String) {
+    super.init(name: name, managedObjectModel: Database.entityModel)
   }
 }
 
@@ -13,8 +17,7 @@ final class Database {
   let context: NSManagedObjectContext
   private(set) var url: URL?
 
-  init(name: String) {
-    let container = Container(name: name, managedObjectModel: Self.entityModel)
+  init(name: String, container: NSPersistentContainer) {
     context = container.viewContext
     container.loadPersistentStores { description, error in
       if let error = error {

--- a/Sources/CoreData/MultiCoreDataStore.swift
+++ b/Sources/CoreData/MultiCoreDataStore.swift
@@ -30,12 +30,22 @@ public final class MultiCoreDataStore<
   /// doing this might cause stores to have corrupted data.
   ///
   /// - Parameter databaseName: store's database name.
+  /// - Parameter containerProvider: Optional closure that can be used to provide a custom
+  /// provider for the given entity model. Defaults to `nil` which uses the default container.
+  ///
+  /// > Important: If you decided to use a custom container, do not forget to set containers's
+  /// `managedObjectModel` to the provided model.
   ///
   /// > Note: Creating a store is a fairly cheap operation, you can create multiple instances of the same store
   /// with a same database name.
-  public init(databaseName: String) {
+  public init(
+    databaseName: String,
+    containerProvider: ((NSManagedObjectModel) -> NSPersistentContainer)? = nil
+  ) {
     self.databaseName = databaseName
-    database = .init(name: databaseName)
+    let container = containerProvider?(Database.entityModel)
+    ?? Container(name: databaseName)
+    database = .init(name: databaseName, container: container)
   }
 
   /// URL for where the core data SQLite database is stored.

--- a/Sources/CoreData/SingleCoreDataStore.swift
+++ b/Sources/CoreData/SingleCoreDataStore.swift
@@ -29,12 +29,22 @@ public final class SingleCoreDataStore<Object: Codable>: SingleObjectStore {
   /// doing this might cause stores to have corrupted data.
   ///
   /// - Parameter databaseName: store's database name.
+  /// - Parameter containerProvider: Optional closure that can be used to provide a custom
+  /// provider for the given entity model. Defaults to `nil` which uses the default container.
+  ///
+  /// > Important: If you decided to use a custom container, do not forget to set containers's
+  /// `managedObjectModel` to the provided model.
   ///
   /// > Note: Creating a store is a fairly cheap operation, you can create multiple instances of the same store
   /// with a same database name.
-  public init(databaseName: String) {
+  public init(
+    databaseName: String,
+    containerProvider: ((NSManagedObjectModel) -> NSPersistentContainer)? = nil
+  ) {
     self.databaseName = databaseName
-    database = .init(name: databaseName)
+    let container = containerProvider?(Database.entityModel)
+    ?? Container(name: databaseName)
+    database = .init(name: databaseName, container: container)
   }
 
   /// URL for where the core data SQLite database is stored.

--- a/Sources/FileSystem/MultiFileSystemStore.swift
+++ b/Sources/FileSystem/MultiFileSystemStore.swift
@@ -15,32 +15,56 @@ public final class MultiFileSystemStore<
   let lock = NSRecursiveLock()
   let logger = Logger()
 
-  /// Store's unique identifier.
-  ///
-  /// > Important: Never use the same identifier for multiple stores with different object types,
-  /// doing this might cause stores to have corrupted data.
-  public let identifier: String
-
   /// Directory where the store folder is created.
   public let directory: FileManager.SearchPathDirectory
 
-  /// Initialize store with given identifier.
+  /// Store's path.
   ///
-  /// > Important: Never use the same identifier for multiple stores with different object types,
+  /// > Note: This is used to create the directory where files are saved:
+  /// >
+  /// > `{directory}/Stores/MultiObjects/{path}/{ID}.json`
+  ///
+  /// > Important: Never use the same path for multiple stores with different object types,
+  /// doing this might cause stores to have corrupted data.
+  public let path: String
+
+  /// Initialize store with given directory and path.
+  ///
+  /// > Important: Never use the same path for multiple stores with different object types,
   /// doing this might cause stores to have corrupted data.
   ///
-  /// - Parameter identifier: store's unique identifier.
   /// - Parameter directory: directory where the store folder is created.
   /// Defaults to `.applicationSupportDirectory`
+  /// - Parameter path: store's path.
   ///
-  /// > Note: Creating a store is a fairly cheap operation, you can create multiple instances of the same store
-  /// with a same identifier and directory.
+  /// > Note: Directory and path are used to create the directory where files are saved:
+  /// >
+  /// > `{directory}/Stores/MultiObjects/{path}/{ID}.json`
+  /// >
+  /// > Creating a store is a fairly cheap operation, you can create multiple instances of the same store
+  /// with a same directory and path.
+  public required init(
+    directory: FileManager.SearchPathDirectory = .applicationSupportDirectory,
+    path: String
+  ) {
+    self.directory = directory
+    self.path = path
+  }
+
+  // MARK: - Deprecated
+
+  /// Deprecated: Store's unique identifier.
+  @available(*, deprecated, renamed: "path")
+  public var identifier: String { path }
+
+  /// Deprecated: Initialize store with given identifier and directory.
+  @available(*, deprecated, renamed: "init(directory:path:)")
   public required init(
     identifier: String,
     directory: FileManager.SearchPathDirectory = .applicationSupportDirectory
   ) {
-    self.identifier = identifier
     self.directory = directory
+    self.path = identifier
   }
 
   // MARK: - MultiObjectStore
@@ -203,7 +227,7 @@ extension MultiFileSystemStore {
       )
       .appendingPathComponent("Stores", isDirectory: true)
       .appendingPathComponent("MultiObjects", isDirectory: true)
-      .appendingPathComponent(identifier, isDirectory: true)
+      .appendingPathComponent(path, isDirectory: true)
     if manager.fileExists(atPath: url.path) == false {
       try manager.createDirectory(
         atPath: url.path,

--- a/Sources/FileSystem/SingleFileSystemStore.swift
+++ b/Sources/FileSystem/SingleFileSystemStore.swift
@@ -13,32 +13,56 @@ public final class SingleFileSystemStore<Object: Codable>: SingleObjectStore {
   let lock = NSRecursiveLock()
   let logger = Logger()
 
-  /// Store's unique identifier.
-  ///
-  /// > Important: Never use the same identifier for multiple stores with different object types,
-  /// doing this might cause stores to have corrupted data.
-  public let identifier: String
-
   /// Directory where the store folder is created.
   public let directory: FileManager.SearchPathDirectory
 
-  /// Initialize store with given identifier.
+  /// Store's path.
   ///
-  /// > Important: Never use the same identifier for multiple stores with different object types,
+  /// > Note: This is used to create the directory where the file is saved:
+  /// >
+  /// > `{directory}/Stores/SingleObject/{path}/object.json`
+  ///
+  /// > Important: Never use the same path for multiple stores with different object types,
+  /// doing this might cause stores to have corrupted data.
+  public let path: String
+
+  /// Initialize store with given directory and path.
+  ///
+  /// > Important: Never use the same path for multiple stores with different object types,
   /// doing this might cause stores to have corrupted data.
   ///
-  /// - Parameter identifier: store's unique identifier.
   /// - Parameter directory: directory where the store folder is created.
   /// Defaults to `.applicationSupportDirectory`
+  /// - Parameter path: store's path.
   ///
-  /// > Note: Creating a store is a fairly cheap operation, you can create multiple instances of the same store
-  /// with a same identifier and directory.
+  /// > Note: Directory and path are used to create the directory where the file is saved:
+  /// >
+  /// > `{directory}/Stores/SingleObject/{path}/object.json`
+  /// >
+  /// > Creating a store is a fairly cheap operation, you can create multiple instances of the same store
+  /// with a same directory and path.
+  public required init(
+    directory: FileManager.SearchPathDirectory = .applicationSupportDirectory,
+    path: String
+  ) {
+    self.directory = directory
+    self.path = path
+  }
+
+  // MARK: - Deprecated
+
+  /// Deprecated: Store's unique identifier.
+  @available(*, deprecated, renamed: "name")
+  public var identifier: String { path }
+
+  /// Deprecated: Initialize store with given identifier and directory.
+  @available(*, deprecated, renamed: "init(directory:name:)")
   public required init(
     identifier: String,
     directory: FileManager.SearchPathDirectory = .applicationSupportDirectory
   ) {
-    self.identifier = identifier
     self.directory = directory
+    self.path = identifier
   }
 
   // MARK: - SingleObjectStore
@@ -100,7 +124,7 @@ extension SingleFileSystemStore {
       )
       .appendingPathComponent("Stores", isDirectory: true)
       .appendingPathComponent("SingleObject", isDirectory: true)
-      .appendingPathComponent(identifier, isDirectory: true)
+      .appendingPathComponent(path, isDirectory: true)
     if manager.fileExists(atPath: url.path) == false {
       try manager.createDirectory(
         atPath: url.path,

--- a/Sources/Keychain/MultiKeychainStore.swift
+++ b/Sources/Keychain/MultiKeychainStore.swift
@@ -19,6 +19,11 @@ public final class MultiKeychainStore<
 
   /// Store's unique identifier.
   ///
+  /// Note: This is used to create the underlying service name `kSecAttrService` where objects are
+  /// stored.
+  ///
+  /// `com.omaralbeik.stores.multi.{identifier}`
+  ///
   /// > Important: Never use the same identifier for multiple stores with different object types,
   /// doing this might cause stores to have corrupted data.
   public let identifier: String
@@ -27,6 +32,11 @@ public final class MultiKeychainStore<
   public let accessibility: KeychainAccessibility
 
   /// Initialize store.
+  ///
+  /// Note: This is used to create the underlying service name `kSecAttrService` where objects are
+  /// stored.
+  ///
+  /// `com.omaralbeik.stores.multi.{identifier}`
   ///
   /// > Important: Never use the same identifier for multiple stores with different object types,
   /// doing this might cause stores to have corrupted data.

--- a/Sources/Keychain/SingleKeychainStore.swift
+++ b/Sources/Keychain/SingleKeychainStore.swift
@@ -17,6 +17,11 @@ public final class SingleKeychainStore<Object: Codable>: SingleObjectStore {
 
   /// Store's unique identifier.
   ///
+  /// Note: This is used to create the underlying service name `kSecAttrService` where the object is
+  /// stored.
+  ///
+  /// `com.omaralbeik.stores.single.{identifier}`
+  ///
   /// > Important: Never use the same identifier for multiple stores with different object types,
   /// doing this might cause stores to have corrupted data.
   public let identifier: String
@@ -25,6 +30,11 @@ public final class SingleKeychainStore<Object: Codable>: SingleObjectStore {
   public let accessibility: KeychainAccessibility
 
   /// Initialize store.
+  ///
+  /// Note: This is used to create the underlying service name `kSecAttrService` where the object is
+  /// stored.
+  ///
+  /// `com.omaralbeik.stores.single.{identifier}`
   ///
   /// > Important: Never use the same identifier for multiple stores with different object types,
   /// doing this might cause stores to have corrupted data.

--- a/Tests/CoreData/DatabaseTests.swift
+++ b/Tests/CoreData/DatabaseTests.swift
@@ -33,7 +33,7 @@ final class DatabaseTests: XCTestCase {
   }
 
   func testEntitiesFetchRequest() {
-    let database = Database(name: "test")
+    let database = Database(name: "test", container: Container(name: "test"))
     let request = database.entitiesFetchRequest()
     XCTAssertEqual(request.entityName, "Entity")
     XCTAssertEqual(
@@ -43,7 +43,7 @@ final class DatabaseTests: XCTestCase {
   }
 
   func testEntityFetchRequest() {
-    let database = Database(name: "test")
+    let database = Database(name: "test", container: Container(name: "test"))
     let id = "test-id"
     let request = database.entityFetchRequest(id)
     XCTAssertEqual(request.entityName, "Entity")
@@ -52,6 +52,12 @@ final class DatabaseTests: XCTestCase {
       NSPredicate(format: "id == %@", id)
     )
     XCTAssertEqual(request.fetchLimit, 1)
+  }
+}
+
+final class TestContainer: NSPersistentContainer {
+  override class func defaultDirectoryURL() -> URL {
+    super.defaultDirectoryURL().appendingPathComponent("Test")
   }
 }
 

--- a/Tests/CoreData/MultiCoreDataStoreTests.swift
+++ b/Tests/CoreData/MultiCoreDataStoreTests.swift
@@ -21,6 +21,18 @@ final class MultiCoreDataStoreTests: XCTestCase {
     XCTAssertEqual(store.databaseName, databaseName)
   }
 
+  func testCreateStoreWithCustomContainer() {
+    let databaseName = UUID().uuidString
+    let store = MultiCoreDataStore<User>(databaseName: databaseName) { model in
+      TestContainer(name: databaseName, managedObjectModel: model)
+    }
+    self.store = store
+
+    let path = store.databaseURL?.pathComponents.suffix(2).joined(separator: "/")
+    let expectedPath = "Test/\(databaseName).sqlite"
+    XCTAssertEqual(path, expectedPath)
+  }
+
   func testDatabaseURL() {
     let store = createFreshUsersStore()
     let path = store.databaseURL?.pathComponents.suffix(2)

--- a/Tests/CoreData/SingleCoreDataStoreTests.swift
+++ b/Tests/CoreData/SingleCoreDataStoreTests.swift
@@ -20,6 +20,19 @@ final class SingleCoreDataStoreTests: XCTestCase {
     XCTAssertEqual(store.databaseName, databaseName)
   }
 
+
+  func testCreateStoreWithCustomContainer() {
+    let databaseName = UUID().uuidString
+    let store = SingleCoreDataStore<User>(databaseName: databaseName) { model in
+      TestContainer(name: databaseName, managedObjectModel: model)
+    }
+    self.store = store
+
+    let path = store.databaseURL?.pathComponents.suffix(2).joined(separator: "/")
+    let expectedPath = "Test/\(databaseName).sqlite"
+    XCTAssertEqual(path, expectedPath)
+  }
+
   func testDatabaseURL() {
     let store = createFreshUserStore()
     let path = store.databaseURL?.pathComponents.suffix(2)

--- a/Tests/FileSystem/MultiFileSystemStoreTests.swift
+++ b/Tests/FileSystem/MultiFileSystemStoreTests.swift
@@ -15,14 +15,23 @@ final class MultiFileSystemStoreTests: XCTestCase {
   }
 
   func testCreateStore() {
+    let directory = FileManager.SearchPathDirectory.documentDirectory
+    let path = UUID().uuidString
+    let store = createFreshUsersStore(directory: directory, path: path)
+    XCTAssertEqual(store.directory, directory)
+    XCTAssertEqual(store.path, path)
+  }
+
+  func testDeprecatedCreateStore() {
     let identifier = UUID().uuidString
     let directory = FileManager.SearchPathDirectory.documentDirectory
-    let store = createFreshUsersStore(
+    let store = MultiFileSystemStore<User>(
       identifier: identifier,
       directory: directory
     )
-    XCTAssertEqual(store.identifier, identifier)
-    XCTAssertEqual(store.directory, directory)
+    XCTAssertEqual(identifier, store.identifier)
+    XCTAssertEqual(directory, store.directory)
+    self.store = store
   }
 
   func testSaveObject() throws {
@@ -304,8 +313,8 @@ final class MultiFileSystemStoreTests: XCTestCase {
 
 private extension MultiFileSystemStoreTests {
   func storeURL(
-    identifier: String = "users",
-    directory: FileManager.SearchPathDirectory = .cachesDirectory
+    directory: FileManager.SearchPathDirectory = .cachesDirectory,
+    path: String = "users"
   ) throws -> URL {
     return try manager.url(
       for: directory,
@@ -315,7 +324,7 @@ private extension MultiFileSystemStoreTests {
     )
     .appendingPathComponent("Stores", isDirectory: true)
     .appendingPathComponent("MultiObjects", isDirectory: true)
-    .appendingPathComponent(identifier, isDirectory: true)
+    .appendingPathComponent(path, isDirectory: true)
   }
 
   func url(forUserWithId id: User.ID) throws -> URL {
@@ -354,13 +363,11 @@ private extension MultiFileSystemStoreTests {
   }
 
   func createFreshUsersStore(
-    identifier: String = "users",
-    directory: FileManager.SearchPathDirectory = .cachesDirectory
+    directory: FileManager.SearchPathDirectory = .cachesDirectory,
+    path: String = "users"
   ) -> MultiFileSystemStore<User> {
-    let store = MultiFileSystemStore<User>(
-      identifier: identifier,
-      directory: directory
-    )
+    let store = MultiFileSystemStore<User>(directory: directory, path: path)
+    XCTAssertEqual(path, store.identifier)
     XCTAssertNoThrow(try store.removeAll())
     self.store = store
     return store

--- a/Tests/UserDefaults/MultiUserDefaultsStoreTests.swift
+++ b/Tests/UserDefaults/MultiUserDefaultsStoreTests.swift
@@ -12,9 +12,16 @@ final class MultiUserDefaultsStoreTests: XCTestCase {
   }
 
   func testCreateStore() {
+    let suiteName = UUID().uuidString
+    let store = createFreshUsersStore(suiteName: suiteName)
+    XCTAssertEqual(store.suiteName, suiteName)
+  }
+
+  func testDeprecatedCreateStore() {
     let identifier = UUID().uuidString
-    let store = createFreshUsersStore(identifier: identifier)
-    XCTAssertEqual(store.identifier, identifier)
+    let store = MultiUserDefaultsStore<User>(identifier: identifier)
+    XCTAssertEqual(identifier, store.identifier)
+    self.store = store
   }
 
   func testSaveObject() throws {
@@ -211,9 +218,10 @@ final class MultiUserDefaultsStoreTests: XCTestCase {
 
 private extension MultiUserDefaultsStoreTests {
   func createFreshUsersStore(
-    identifier: String = "users"
+    suiteName: String = "users"
   ) -> MultiUserDefaultsStore<User> {
-    let store = MultiUserDefaultsStore<User>(identifier: identifier)
+    let store = MultiUserDefaultsStore<User>(suiteName: suiteName)
+    XCTAssertEqual(suiteName, store.identifier)
     store.removeAll()
     self.store = store
     return store

--- a/Tests/UserDefaults/SingleUserDefaultsStoreTests.swift
+++ b/Tests/UserDefaults/SingleUserDefaultsStoreTests.swift
@@ -12,9 +12,16 @@ final class SingleUserDefaultsStoreTests: XCTestCase {
   }
 
   func testCreateStore() {
+    let suiteName = UUID().uuidString
+    let store = createFreshUserStore(suiteName: suiteName)
+    XCTAssertEqual(store.suiteName, suiteName)
+  }
+
+  func testDeprecatedCreateStore() {
     let identifier = UUID().uuidString
-    let store = createFreshUserStore(identifier: identifier)
-    XCTAssertEqual(store.identifier, identifier)
+    let store = SingleUserDefaultsStore<User>(identifier: identifier)
+    XCTAssertEqual(identifier, store.identifier)
+    self.store = store
   }
 
   func testSaveObject() throws {
@@ -61,9 +68,10 @@ final class SingleUserDefaultsStoreTests: XCTestCase {
 
 private extension SingleUserDefaultsStoreTests {
   func createFreshUserStore(
-    identifier: String = "user"
+    suiteName: String = "user"
   ) -> SingleUserDefaultsStore<User> {
-    let store = SingleUserDefaultsStore<User>(identifier: identifier)
+    let store = SingleUserDefaultsStore<User>(suiteName: suiteName)
+    XCTAssertEqual(suiteName, store.identifier)
     store.remove()
     self.store = store
     return store


### PR DESCRIPTION
## Changes

- `MultiUserDefaultsStore.identifier` and `SingleUserDefaultsStore.identifier` properties has been renamed to `suiteName` to reflect the usage in UserDefaults.
- `MultiFileSystemStore.identifier` and `SingleFileSystemStore.identifier` properties has been renamed to `path` to reflect the usage in file system.
- `MultiCoreDataStore.identifier` and `SingleCoreDataStore.identifier` properties has been renamed to `databaseName` to reflect the usage in Core Data.
- `MultiCoreDataStore` and `SingleCoreDataStore` initializers has a new `containerProvider` argument that allows providing custom `NSPersistentContainer`, closes #15
- Add better documentation in all stores.

