### PR TITLE
Replace modules chart PNG with mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,56 +35,42 @@ graph TB
     classDef erased fill:#FFCC80,stroke:#E65100,stroke-width:2px,color:#000
     classDef impl fill:#90CAF9,stroke:#1565C0,stroke-width:2px,color:#000
     classDef fake fill:#CE93D8,stroke:#6A1B9A,stroke-width:2px,color:#000
-    classDef module fill:transparent,stroke:#888,stroke-width:1px,stroke-dasharray:4 3
 
-    subgraph BP[Blueprints]
+    subgraph SINGLE["&nbsp;Single Object Stores&nbsp;"]
+        direction TB
         SOS["SingleObjectStore<br/>«protocol»"]:::protocol
-        MOS["MultiObjectStore<br/>«protocol»"]:::protocol
         ASOS["AnySingleObjectStore<br/>«type-erased»"]:::erased
+        SUD["SingleUserDefaultsStore<br/>(UserDefaultsStore)"]:::impl
+        SFS["SingleFileSystemStore<br/>(FileSystemStore)"]:::impl
+        SCD["SingleCoreDataStore<br/>(CoreDataStore)"]:::impl
+        SKC["SingleKeychainStore<br/>(KeychainStore)"]:::impl
+        SOSF["SingleObjectStoreFake<br/>(TestUtils)"]:::fake
+
+        ASOS -. wraps .-> SOS
+        SUD ==> SOS
+        SFS ==> SOS
+        SCD ==> SOS
+        SKC ==> SOS
+        SOSF ==> SOS
+    end
+
+    subgraph MULTI["&nbsp;Multi Object Stores&nbsp;"]
+        direction TB
+        MOS["MultiObjectStore<br/>«protocol»"]:::protocol
         AMOS["AnyMultiObjectStore<br/>«type-erased»"]:::erased
+        MUD["MultiUserDefaultsStore<br/>(UserDefaultsStore)"]:::impl
+        MFS["MultiFileSystemStore<br/>(FileSystemStore)"]:::impl
+        MCD["MultiCoreDataStore<br/>(CoreDataStore)"]:::impl
+        MKC["MultiKeychainStore<br/>(KeychainStore)"]:::impl
+        MOSF["MultiObjectStoreFake<br/>(TestUtils)"]:::fake
+
+        AMOS -. wraps .-> MOS
+        MUD ==> MOS
+        MFS ==> MOS
+        MCD ==> MOS
+        MKC ==> MOS
+        MOSF ==> MOS
     end
-
-    subgraph UDS[UserDefaultsStore]
-        SUD["SingleUserDefaultsStore"]:::impl
-        MUD["MultiUserDefaultsStore"]:::impl
-    end
-
-    subgraph FSS[FileSystemStore]
-        SFS["SingleFileSystemStore"]:::impl
-        MFS["MultiFileSystemStore"]:::impl
-    end
-
-    subgraph CDS[CoreDataStore]
-        SCD["SingleCoreDataStore"]:::impl
-        MCD["MultiCoreDataStore"]:::impl
-    end
-
-    subgraph KCS[KeychainStore]
-        SKC["SingleKeychainStore"]:::impl
-        MKC["MultiKeychainStore"]:::impl
-    end
-
-    subgraph TU[TestUtils]
-        SOSF["SingleObjectStoreFake"]:::fake
-        MOSF["MultiObjectStoreFake"]:::fake
-    end
-
-    class BP,UDS,FSS,CDS,KCS,TU module
-
-    ASOS -. wraps .-> SOS
-    AMOS -. wraps .-> MOS
-
-    SUD ==> SOS
-    SFS ==> SOS
-    SCD ==> SOS
-    SKC ==> SOS
-    SOSF ==> SOS
-
-    MUD ==> MOS
-    MFS ==> MOS
-    MCD ==> MOS
-    MKC ==> MOS
-    MOSF ==> MOS
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -29,8 +29,50 @@ It all boils down to the two protocols [`SingleObjectStore`](https://github.com/
 
 The two protocols are then implemented in the different modules as explained in the chart below:
 
-![Modules chart](https://raw.githubusercontent.com/omaralbeik/Stores/main/Assets/stores-light.png#gh-light-mode-only)
-![Modules chart](https://raw.githubusercontent.com/omaralbeik/Stores/main/Assets/stores-dark.png#gh-dark-mode-only)
+```mermaid
+graph TD
+    subgraph Blueprints
+        SOS[SingleObjectStore]
+        MOS[MultiObjectStore]
+    end
+
+    subgraph UserDefaultsStore
+        SUD[SingleUserDefaultsStore]
+        MUD[MultiUserDefaultsStore]
+    end
+
+    subgraph FileSystemStore
+        SFS[SingleFileSystemStore]
+        MFS[MultiFileSystemStore]
+    end
+
+    subgraph CoreDataStore
+        SCD[SingleCoreDataStore]
+        MCD[MultiCoreDataStore]
+    end
+
+    subgraph KeychainStore
+        SKC[SingleKeychainStore]
+        MKC[MultiKeychainStore]
+    end
+
+    subgraph TestUtils
+        SOSF[SingleObjectStoreFake]
+        MOSF[MultiObjectStoreFake]
+    end
+
+    SUD --> SOS
+    SFS --> SOS
+    SCD --> SOS
+    SKC --> SOS
+    SOSF --> SOS
+
+    MUD --> MOS
+    MFS --> MOS
+    MCD --> MOS
+    MKC --> MOS
+    MOSF --> MOS
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,48 +30,61 @@ It all boils down to the two protocols [`SingleObjectStore`](https://github.com/
 The two protocols are then implemented in the different modules as explained in the chart below:
 
 ```mermaid
-graph TD
-    subgraph Blueprints
-        SOS[SingleObjectStore]
-        MOS[MultiObjectStore]
+graph TB
+    classDef protocol fill:#FFE082,stroke:#F57C00,stroke-width:2px,color:#000
+    classDef erased fill:#FFCC80,stroke:#E65100,stroke-width:2px,color:#000
+    classDef impl fill:#90CAF9,stroke:#1565C0,stroke-width:2px,color:#000
+    classDef fake fill:#CE93D8,stroke:#6A1B9A,stroke-width:2px,color:#000
+    classDef module fill:transparent,stroke:#888,stroke-width:1px,stroke-dasharray:4 3
+
+    subgraph BP[Blueprints]
+        SOS["SingleObjectStore<br/>«protocol»"]:::protocol
+        MOS["MultiObjectStore<br/>«protocol»"]:::protocol
+        ASOS["AnySingleObjectStore<br/>«type-erased»"]:::erased
+        AMOS["AnyMultiObjectStore<br/>«type-erased»"]:::erased
     end
 
-    subgraph UserDefaultsStore
-        SUD[SingleUserDefaultsStore]
-        MUD[MultiUserDefaultsStore]
+    subgraph UDS[UserDefaultsStore]
+        SUD["SingleUserDefaultsStore"]:::impl
+        MUD["MultiUserDefaultsStore"]:::impl
     end
 
-    subgraph FileSystemStore
-        SFS[SingleFileSystemStore]
-        MFS[MultiFileSystemStore]
+    subgraph FSS[FileSystemStore]
+        SFS["SingleFileSystemStore"]:::impl
+        MFS["MultiFileSystemStore"]:::impl
     end
 
-    subgraph CoreDataStore
-        SCD[SingleCoreDataStore]
-        MCD[MultiCoreDataStore]
+    subgraph CDS[CoreDataStore]
+        SCD["SingleCoreDataStore"]:::impl
+        MCD["MultiCoreDataStore"]:::impl
     end
 
-    subgraph KeychainStore
-        SKC[SingleKeychainStore]
-        MKC[MultiKeychainStore]
+    subgraph KCS[KeychainStore]
+        SKC["SingleKeychainStore"]:::impl
+        MKC["MultiKeychainStore"]:::impl
     end
 
-    subgraph TestUtils
-        SOSF[SingleObjectStoreFake]
-        MOSF[MultiObjectStoreFake]
+    subgraph TU[TestUtils]
+        SOSF["SingleObjectStoreFake"]:::fake
+        MOSF["MultiObjectStoreFake"]:::fake
     end
 
-    SUD --> SOS
-    SFS --> SOS
-    SCD --> SOS
-    SKC --> SOS
-    SOSF --> SOS
+    class BP,UDS,FSS,CDS,KCS,TU module
 
-    MUD --> MOS
-    MFS --> MOS
-    MCD --> MOS
-    MKC --> MOS
-    MOSF --> MOS
+    ASOS -. wraps .-> SOS
+    AMOS -. wraps .-> MOS
+
+    SUD ==> SOS
+    SFS ==> SOS
+    SCD ==> SOS
+    SKC ==> SOS
+    SOSF ==> SOS
+
+    MUD ==> MOS
+    MFS ==> MOS
+    MCD ==> MOS
+    MKC ==> MOS
+    MOSF ==> MOS
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Replaces the dual light/dark PNG references in the README with an inline mermaid `graph TD`.
- GitHub renders mermaid natively and auto-themes for light/dark, so the `#gh-*-mode-only` workaround is no longer needed.
- The diagram conveys the same information: each `Single*` / `Multi*` implementation across the four backends (and the test fakes) points to its protocol in `Blueprints`.

## Test plan
- [ ] Open the README on GitHub and confirm the mermaid diagram renders correctly in both light and dark mode.
- [ ] Verify all six module groupings (Blueprints, UserDefaultsStore, FileSystemStore, CoreDataStore, KeychainStore, TestUtils) and their conformance arrows are visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)